### PR TITLE
Add help description to the v-shell component

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,14 @@ export default {
       },
       commands: [
         { name: "info",
+          desc: "Show information about this terminal",
           get() {
             return `<p>With ❤️ By Salah Bentayeb @halasproject.</p>`;
         }
         },
         {
           name: "uname",
+          desc: "Show the current terminal name",
           get() {
             return navigator.appVersion;
           }
@@ -155,6 +157,7 @@ export default {
 ```javascript
 [
   { name: String,
+    desc: String,
     get() {
        return String | HTML;
     }

--- a/src/v-shell.vue
+++ b/src/v-shell.vue
@@ -83,10 +83,14 @@ export default {
   },
   computed: {
     allcommands() {
-      var tab = ["help", "clear"];
+      var tab = [
+        { name: "help", desc: "Show all the commands that are available" },
+        { name: "clear", desc: "Clear the terminal of all output" },
+      ];
+
       if (this.commands) {
-        this.commands.forEach(a => {
-          tab.push(a.name);
+        this.commands.forEach(({ name, desc }) => {
+          tab.push({ name, desc });
         });
       }
 
@@ -163,8 +167,16 @@ export default {
         this.$refs.output.innerHTML = "";
         this.value = "";
       } else if (cmd == "help") {
+        var commandsList = this.allcommands.map(({ name, desc}) => {
+          if (desc) {
+            return `${name}: ${desc}`;
+          }
+
+          return name;
+        });
+
         this.output(
-          '<div class="ls-files">' + this.allcommands.join("<br>") + "</div>"
+            '<div class="ls-files">' + commandsList.join("<br>") + "</div>"
         );
       } else {
         if (this.commands) {


### PR DESCRIPTION
Just like true terminals, it would be great to show descriptions in the help output.

To that end, I've added a new parameter to the `commands` array called `desc` which accepts a `String`.

I have rewritten `allCommands` to return an array of `name`, `desc` objects. Which is then mapped to a `String` with the `desc` if it exists otherwise it just outputs the `name`.

I've also updated the documentation to show the `desc` in use and what it accepts.